### PR TITLE
fix: change GetResumeCounter auth to Anonymous

### DIFF
--- a/backend/api/GetResumeCounter.cs
+++ b/backend/api/GetResumeCounter.cs
@@ -17,7 +17,7 @@ namespace Company.Function
 
         [Function("GetResumeCounter")]
         public MultiResponse Run(
-            [HttpTrigger(AuthorizationLevel.Function, "get", "post")] HttpRequestData req,
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
             [CosmosDBInput(
                 databaseName: CosmosConstants.COSMOS_DB_DATABASE_NAME,
                 containerName: CosmosConstants.COSMOS_DB_CONTAINER_NAME,


### PR DESCRIPTION
Changes `AuthorizationLevel.Function` to `AuthorizationLevel.Anonymous` on the `GetResumeCounter` endpoint.

## Problem
The visitor counter API requires a function key (`?code=<key>`) but the CI/CD pipeline never injects it into `config.js`. This causes 401 Unauthorized errors visible in browser DevTools when visiting `https://resumedevv1.ryanmcvey.me`.

## Fix
The counter is a public read/increment endpoint — no sensitive data. Changing to `Anonymous` auth removes the key requirement entirely, which is the simplest and most appropriate fix.

If rate limiting or abuse protection is needed later, it should be handled at the Cloudflare CDN layer (WAF rules) rather than a client-side function key.

## Testing
- Backend builds successfully
- All 8 unit tests pass
- No other references to `AuthorizationLevel` in the test suite

Fixes #198