### PR TITLE
fix: repo detection, idempotent protection config, dynamic stack naming

### DIFF
--- a/scripts/configure-repo-protection.sh
+++ b/scripts/configure-repo-protection.sh
@@ -1,32 +1,34 @@
 #!/usr/bin/env bash
 # configure-repo-protection.sh
-# Configures GitHub environment protection rules and branch protection rules
-# for the Azure Resume IaC project.
+# Idempotent configuration of GitHub environment protection rules and branch
+# protection rules for the Azure Resume IaC project.
 #
-# This script:
-#   1. Captures pre-configuration state snapshot
-#   2. Configures production environment (required reviewer, wait timer, branch policy)
-#   3. Configures development environment (branch policy)
-#   4. Configures main branch protection (require PR, admin bypass)
-#   5. Configures develop branch protection (require PR, admin bypass)
-#   6. Captures post-configuration state snapshot
-#   7. Compares and displays pre/post differences
+# The script defines a desired state for 4 resources (production environment,
+# development environment, main branch protection, develop branch protection),
+# compares current state against desired state, and only applies changes when
+# drift is detected.
 #
 # Usage:
 #   bash scripts/configure-repo-protection.sh [options]
 #
 # Options:
-#   --dry-run           Assess current state only, make no changes
+#   --dry-run           Audit current state vs desired — no changes (exit 0=compliant, 2=drift)
 #   --reviewer <user>   GitHub username for required reviewer (default: repo owner)
-#   --repo <owner/repo> Target repository (default: auto-detect from gh)
+#   --repo <owner/repo> Target repository (default: auto-detect from git origin remote)
 #   --wait-timer <min>  Wait timer in minutes for production (default: 5)
 #   --skip-branch       Skip branch protection rules (environment only)
 #   --skip-environment  Skip environment protection rules (branch only)
 #   -h, --help          Show usage
 #
+# Exit codes:
+#   0  Success (all compliant, or drift fixed)
+#   1  Error (prerequisite failure, API error)
+#   2  Drift detected (--dry-run only)
+#
 # Prerequisites:
 #   - gh CLI authenticated with 'repo' scope (verify with: gh auth status -t)
 #   - jq installed
+#   - git (for auto-detect repo from origin remote)
 #   - Repository admin permissions
 
 set -euo pipefail
@@ -60,9 +62,9 @@ usage() {
 Usage: $(basename "$0") [options]
 
 Options:
-  --dry-run           Assess current state only, make no changes
+  --dry-run           Audit current state vs desired — no changes (exit 0=compliant, 2=drift)
   --reviewer <user>   GitHub username for required reviewer (default: repo owner)
-  --repo <owner/repo> Target repository (default: auto-detect)
+  --repo <owner/repo> Target repository (default: auto-detect from git origin)
   --wait-timer <min>  Wait timer in minutes for production (default: 5)
   --skip-branch       Skip branch protection rules
   --skip-environment  Skip environment protection rules
@@ -119,13 +121,13 @@ fi
 
 header "Prerequisite Checks"
 
-for cmd in gh jq; do
+for cmd in gh jq git; do
   if ! command -v "$cmd" &>/dev/null; then
     fail "Required command '$cmd' is not installed."
     exit 1
   fi
 done
-success "Required tools found (gh, jq)"
+success "Required tools found (gh, jq, git)"
 
 if ! gh auth status &>/dev/null; then
   fail "GitHub CLI not authenticated. Run: gh auth login --scopes repo"
@@ -135,16 +137,26 @@ fi
 GH_USER=$(gh api user --jq .login 2>/dev/null || echo "unknown")
 success "GitHub CLI authenticated as: $GH_USER"
 
-# Auto-detect repo
+# Auto-detect repo from git origin remote (not gh repo view, which follows
+# fork parents and can resolve to the wrong repository)
 if [[ -z "$REPO" ]]; then
-  REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || echo "")
-  if [[ -z "$REPO" ]]; then
-    fail "Could not detect repository. Use --repo owner/repo"
+  ORIGIN_URL=$(git remote get-url origin 2>/dev/null || echo "")
+  if [[ -n "$ORIGIN_URL" ]]; then
+    REPO=$(echo "$ORIGIN_URL" | sed -E 's#.*github\.com[:/]([^/]+/[^/.]+)(\.git)?$#\1#')
+  fi
+  if [[ -z "$REPO" || "$REPO" == "$ORIGIN_URL" ]]; then
+    fail "Could not detect repository from git origin remote. Use --repo owner/repo"
     exit 1
   fi
 fi
 OWNER=$(echo "$REPO" | cut -d'/' -f1)
 REPO_NAME=$(echo "$REPO" | cut -d'/' -f2)
+
+# Validate the detected repo is accessible
+if ! gh api "repos/${REPO}" --jq '.full_name' &>/dev/null; then
+  fail "Repository '${REPO}' is not accessible. Check permissions or use --repo owner/repo"
+  exit 1
+fi
 success "Target repository: $REPO"
 
 # Default reviewer to repo owner
@@ -163,15 +175,98 @@ info "Reviewer user ID: $REVIEWER_ID"
 
 if [[ "$DRY_RUN" == true ]]; then
   echo ""
-  warn "DRY RUN MODE — no changes will be made"
+  warn "DRY RUN MODE — audit only, no changes will be made"
 fi
 
 # =============================================================================
-# State Snapshot Functions
+# Temp Directory
 # =============================================================================
 
 SNAPSHOT_DIR=$(mktemp -d)
 trap 'rm -rf "$SNAPSHOT_DIR"' EXIT
+
+# =============================================================================
+# Desired State Functions
+# =============================================================================
+# These define the single source of truth for what each resource should look
+# like. The capture functions produce comparable JSON so we can diff.
+
+desired_env_production() {
+  cat <<EOF
+{
+  "exists": true,
+  "protection_rules": [
+    {
+      "type": "required_reviewers",
+      "wait_timer": null,
+      "reviewers": [
+        {
+          "login": "${REVIEWER}",
+          "type": "User"
+        }
+      ]
+    },
+    {
+      "type": "wait_timer",
+      "wait_timer": ${WAIT_TIMER},
+      "reviewers": []
+    }
+  ],
+  "deployment_branch_policy": {
+    "protected_branches": false,
+    "custom_branch_policies": true
+  },
+  "deployment_branch_policies": [
+    {
+      "name": "main",
+      "type": "branch"
+    }
+  ]
+}
+EOF
+}
+
+desired_env_development() {
+  cat <<EOF
+{
+  "exists": true,
+  "protection_rules": [],
+  "deployment_branch_policy": {
+    "protected_branches": false,
+    "custom_branch_policies": true
+  },
+  "deployment_branch_policies": [
+    {
+      "name": "develop",
+      "type": "branch"
+    }
+  ]
+}
+EOF
+}
+
+desired_branch_protection() {
+  # Same desired state for both main and develop branches
+  cat <<EOF
+{
+  "exists": true,
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 1,
+    "dismiss_stale_reviews": false,
+    "require_code_owner_reviews": false
+  },
+  "enforce_admins": false,
+  "required_status_checks": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "required_conversation_resolution": true
+}
+EOF
+}
+
+# =============================================================================
+# State Capture Functions
+# =============================================================================
 
 capture_environment_state() {
   local env_name="$1"
@@ -185,15 +280,17 @@ capture_environment_state() {
     return
   fi
 
-  # Extract protection rules
+  # Extract protection rules in the same shape as desired state.
+  # Filter out "branch_policy" type — GitHub auto-adds this when
+  # custom_branch_policies is true; it's not in our PUT payload.
   local protection_rules
   protection_rules=$(echo "$env_data" | jq '{
     exists: true,
-    protection_rules: [.protection_rules[]? | {
+    protection_rules: [.protection_rules[]? | select(.type != "branch_policy") | {
       type: .type,
       wait_timer: .wait_timer,
       reviewers: [.reviewers[]? | {login: .reviewer.login, type: .type}]
-    }],
+    }] | sort_by(.type),
     deployment_branch_policy: .deployment_branch_policy
   }' 2>/dev/null || echo '{"exists": true, "error": "parse_failed"}')
 
@@ -206,8 +303,10 @@ capture_environment_state() {
   if [[ "$branch_policy_type" == "true" ]]; then
     local branch_policies
     branch_policies=$(gh api "repos/${REPO}/environments/${env_name}/deployment-branch-policies" 2>/dev/null || echo '{"branch_policies": []}')
+    # Merge deployment_branch_policies (name + type only, to match desired state shape)
     local merged
-    merged=$(jq -s '.[0] * {deployment_branch_policies: .[1].branch_policies}' "$output_file" <(echo "$branch_policies") 2>/dev/null || cat "$output_file")
+    merged=$(jq -s '.[0] * {deployment_branch_policies: [.[1].branch_policies[]? | {name: .name, type: .type}]}' \
+      "$output_file" <(echo "$branch_policies") 2>/dev/null || cat "$output_file")
     echo "$merged" > "$output_file"
   fi
 }
@@ -255,44 +354,241 @@ display_state() {
 }
 
 # =============================================================================
-# Step 1: Capture Pre-Configuration State
+# Drift Detection
+# =============================================================================
+# Compares current state JSON against desired state JSON.
+# Returns 0 if compliant, 1 if drift detected.
+# Writes the diff to stdout when drift is found.
+
+check_drift() {
+  local label="$1"
+  local current_file="$2"
+  local desired_file="$3"
+
+  # Check for API permission errors — can't determine compliance
+  local current_msg
+  current_msg=$(jq -r '.message // empty' "$current_file" 2>/dev/null || echo "")
+  if [[ "$current_msg" == *"not accessible"* ]] || [[ "$current_msg" == *"integration"* ]]; then
+    warn "SKIPPED: $label — insufficient API permissions (${current_msg})"
+    info "  Branch protection requires 'administration' permission on the token"
+    info "  Re-run outside Codespace with a PAT, or use --skip-branch"
+    # Return special code 2 to distinguish from real drift
+    return 2
+  fi
+
+  local current_sorted desired_sorted
+  current_sorted=$(jq --sort-keys '.' "$current_file" 2>/dev/null || cat "$current_file")
+  desired_sorted=$(jq --sort-keys '.' "$desired_file" 2>/dev/null || cat "$desired_file")
+
+  if diff -q <(echo "$current_sorted") <(echo "$desired_sorted") &>/dev/null; then
+    success "IN COMPLIANCE: $label"
+    return 0
+  else
+    warn "DRIFT DETECTED: $label"
+    diff --color=always \
+      <(echo "$current_sorted") \
+      <(echo "$desired_sorted") \
+      | sed 's/^/  /' || true
+    echo "  (left = current, right = desired)"
+    return 1
+  fi
+}
+
+# =============================================================================
+# Apply Functions (only called when drift is detected)
 # =============================================================================
 
-header "Step 1: Capturing Pre-Configuration State"
+apply_environment() {
+  local env_name="$1"
+  local allowed_branch="$2"
+  local payload="$3"
 
-capture_environment_state "production" "${SNAPSHOT_DIR}/pre_env_production.json"
-capture_environment_state "development" "${SNAPSHOT_DIR}/pre_env_development.json"
-capture_branch_protection_state "main" "${SNAPSHOT_DIR}/pre_branch_main.json"
-capture_branch_protection_state "develop" "${SNAPSHOT_DIR}/pre_branch_develop.json"
+  info "Applying configuration for '${env_name}' environment..."
 
-display_state "Production Environment (before)" "${SNAPSHOT_DIR}/pre_env_production.json"
-display_state "Development Environment (before)" "${SNAPSHOT_DIR}/pre_env_development.json"
-display_state "Main Branch Protection (before)" "${SNAPSHOT_DIR}/pre_branch_main.json"
-display_state "Develop Branch Protection (before)" "${SNAPSHOT_DIR}/pre_branch_develop.json"
+  # Create/update the environment with protection rules
+  local response
+  response=$(echo "$payload" | gh api -X PUT "repos/${REPO}/environments/${env_name}" --input - 2>&1) || {
+    fail "Failed to update '${env_name}' environment:"
+    echo "$response" | sed 's/^/  /'
+    return 1
+  }
 
-if [[ "$DRY_RUN" == true ]]; then
-  header "Dry Run Complete"
-  info "No changes were made. Review the current state above."
-  info "Run without --dry-run to apply protection rules."
-  exit 0
+  # Sync deployment branch policies: compute delta
+  local existing_names desired_name="$allowed_branch"
+  existing_names=$(gh api "repos/${REPO}/environments/${env_name}/deployment-branch-policies" \
+    --jq '[.branch_policies[] | {id: .id, name: .name}]' 2>/dev/null || echo '[]')
+
+  # Remove policies that don't match the desired branch
+  local ids_to_remove
+  ids_to_remove=$(echo "$existing_names" | jq -r --arg desired "$desired_name" \
+    '.[] | select(.name != $desired) | .id' 2>/dev/null || echo "")
+  while IFS= read -r policy_id; do
+    if [[ -n "$policy_id" ]]; then
+      local del_response
+      del_response=$(gh api -X DELETE "repos/${REPO}/environments/${env_name}/deployment-branch-policies/${policy_id}" 2>&1) || {
+        fail "Failed to remove deployment branch policy ${policy_id}:"
+        echo "$del_response" | sed 's/^/  /'
+      }
+      info "  Removed stale policy ID: $policy_id"
+    fi
+  done <<< "$ids_to_remove"
+
+  # Add the desired branch policy if it doesn't already exist
+  local has_desired
+  has_desired=$(echo "$existing_names" | jq -r --arg desired "$desired_name" \
+    '[.[] | select(.name == $desired)] | length' 2>/dev/null || echo "0")
+  if [[ "$has_desired" == "0" ]]; then
+    local add_response
+    add_response=$(gh api -X POST "repos/${REPO}/environments/${env_name}/deployment-branch-policies" \
+      -f name="$desired_name" -f type="branch" 2>&1) || {
+      fail "Failed to add deployment branch policy '${desired_name}':"
+      echo "$add_response" | sed 's/^/  /'
+      return 1
+    }
+    info "  Added deployment branch policy: $desired_name"
+  else
+    info "  Deployment branch policy '$desired_name' already exists"
+  fi
+
+  success "'${env_name}' environment configured"
+}
+
+apply_branch_protection() {
+  local branch="$1"
+
+  info "Applying branch protection for '${branch}'..."
+
+  local response
+  response=$(gh api -X PUT "repos/${REPO}/branches/${branch}/protection" \
+    --input - <<EOF 2>&1
+{
+  "required_status_checks": null,
+  "enforce_admins": false,
+  "required_pull_request_reviews": {
+    "dismiss_stale_reviews": false,
+    "require_code_owner_reviews": false,
+    "required_approving_review_count": 1
+  },
+  "restrictions": null,
+  "required_conversation_resolution": true,
+  "allow_force_pushes": false,
+  "allow_deletions": false
+}
+EOF
+  ) || {
+    fail "Failed to configure '${branch}' branch protection:"
+    echo "$response" | sed 's/^/  /'
+    return 1
+  }
+
+  success "'${branch}' branch protection configured"
+}
+
+# =============================================================================
+# Step 1: Capture Current State
+# =============================================================================
+
+header "Step 1: Capturing Current State"
+
+capture_environment_state "production" "${SNAPSHOT_DIR}/current_env_production.json"
+capture_environment_state "development" "${SNAPSHOT_DIR}/current_env_development.json"
+capture_branch_protection_state "main" "${SNAPSHOT_DIR}/current_branch_main.json"
+capture_branch_protection_state "develop" "${SNAPSHOT_DIR}/current_branch_develop.json"
+
+display_state "Production Environment (current)" "${SNAPSHOT_DIR}/current_env_production.json"
+display_state "Development Environment (current)" "${SNAPSHOT_DIR}/current_env_development.json"
+display_state "Main Branch Protection (current)" "${SNAPSHOT_DIR}/current_branch_main.json"
+display_state "Develop Branch Protection (current)" "${SNAPSHOT_DIR}/current_branch_develop.json"
+
+# =============================================================================
+# Step 2: Write Desired State
+# =============================================================================
+
+header "Step 2: Desired State"
+
+desired_env_production  | jq '.' > "${SNAPSHOT_DIR}/desired_env_production.json"
+desired_env_development | jq '.' > "${SNAPSHOT_DIR}/desired_env_development.json"
+desired_branch_protection | jq '.' > "${SNAPSHOT_DIR}/desired_branch_main.json"
+desired_branch_protection | jq '.' > "${SNAPSHOT_DIR}/desired_branch_develop.json"
+
+display_state "Production Environment (desired)" "${SNAPSHOT_DIR}/desired_env_production.json"
+display_state "Development Environment (desired)" "${SNAPSHOT_DIR}/desired_env_development.json"
+display_state "Main Branch Protection (desired)" "${SNAPSHOT_DIR}/desired_branch_main.json"
+display_state "Develop Branch Protection (desired)" "${SNAPSHOT_DIR}/desired_branch_develop.json"
+
+# =============================================================================
+# Step 3: Drift Detection
+# =============================================================================
+
+header "Step 3: Drift Detection (Current vs Desired)"
+
+DRIFT_COUNT=0
+SKIP_COUNT=0
+DRIFT_ENV_PROD=false
+DRIFT_ENV_DEV=false
+DRIFT_BRANCH_MAIN=false
+DRIFT_BRANCH_DEVELOP=false
+
+run_drift_check() {
+  local label="$1"
+  local current_file="$2"
+  local desired_file="$3"
+  local drift_var="$4"
+
+  local rc=0
+  check_drift "$label" "$current_file" "$desired_file" || rc=$?
+  case "$rc" in
+    0) ;; # compliant
+    1) DRIFT_COUNT=$((DRIFT_COUNT + 1)); eval "${drift_var}=true" ;;
+    2) SKIP_COUNT=$((SKIP_COUNT + 1)) ;; # insufficient permissions
+  esac
+}
+
+if [[ "$SKIP_ENVIRONMENT" != true ]]; then
+  run_drift_check "Production Environment" "${SNAPSHOT_DIR}/current_env_production.json" "${SNAPSHOT_DIR}/desired_env_production.json" DRIFT_ENV_PROD
+  run_drift_check "Development Environment" "${SNAPSHOT_DIR}/current_env_development.json" "${SNAPSHOT_DIR}/desired_env_development.json" DRIFT_ENV_DEV
+fi
+
+if [[ "$SKIP_BRANCH" != true ]]; then
+  run_drift_check "Main Branch Protection" "${SNAPSHOT_DIR}/current_branch_main.json" "${SNAPSHOT_DIR}/desired_branch_main.json" DRIFT_BRANCH_MAIN
+  run_drift_check "Develop Branch Protection" "${SNAPSHOT_DIR}/current_branch_develop.json" "${SNAPSHOT_DIR}/desired_branch_develop.json" DRIFT_BRANCH_DEVELOP
 fi
 
 # =============================================================================
-# Step 2: Configure Production Environment
+# Dry Run: Report and Exit
 # =============================================================================
 
-if [[ "$SKIP_ENVIRONMENT" != true ]]; then
-  header "Step 2: Configuring Production Environment"
+if [[ "$DRY_RUN" == true ]]; then
+  header "Audit Complete"
+  if [[ "$SKIP_COUNT" -gt 0 ]]; then
+    warn "${SKIP_COUNT} resource(s) skipped due to insufficient permissions"
+  fi
+  if [[ "$DRIFT_COUNT" -gt 0 ]]; then
+    warn "${DRIFT_COUNT} resource(s) have configuration drift"
+    info "Run without --dry-run to remediate"
+    exit 2
+  else
+    success "All auditable resources are in compliance — no changes needed"
+    exit 0
+  fi
+fi
 
-  subhead "Creating/updating production environment with protection rules"
-  info "Setting required reviewer: $REVIEWER (ID: $REVIEWER_ID)"
-  info "Setting wait timer: ${WAIT_TIMER} minutes"
-  info "Setting deployment branch policy: main only"
+# =============================================================================
+# Step 4: Apply Remediations (only for drifted resources)
+# =============================================================================
 
-  # Create/update the environment with protection rules
-  # The PUT endpoint creates the environment if it doesn't exist
-  gh api -X PUT "repos/${REPO}/environments/production" \
-    --input - <<EOF
+if [[ "$DRIFT_COUNT" -eq 0 ]]; then
+  header "Step 4: Apply"
+  success "All resources already match desired state — nothing to do"
+else
+  header "Step 4: Applying Remediations (${DRIFT_COUNT} resource(s) drifted)"
+
+  APPLY_FAILURES=0
+
+  if [[ "$DRIFT_ENV_PROD" == true ]]; then
+    subhead "Remediating: Production Environment"
+    info "Desired: reviewer=${REVIEWER}, wait_timer=${WAIT_TIMER}min, branch=main"
+    apply_environment "production" "main" "$(cat <<PAYLOAD
 {
   "wait_timer": ${WAIT_TIMER},
   "prevent_self_review": false,
@@ -307,211 +603,124 @@ if [[ "$SKIP_ENVIRONMENT" != true ]]; then
     "custom_branch_policies": true
   }
 }
-EOF
-  success "Production environment protection rules configured"
-
-  # Set deployment branch policy to main only
-  # First, remove any existing deployment branch policies
-  subhead "Configuring deployment branch policies for production"
-
-  EXISTING_POLICIES=$(gh api "repos/${REPO}/environments/production/deployment-branch-policies" --jq '.branch_policies[].id' 2>/dev/null || echo "")
-  if [[ -n "$EXISTING_POLICIES" ]]; then
-    info "Removing existing deployment branch policies..."
-    while IFS= read -r policy_id; do
-      if [[ -n "$policy_id" ]]; then
-        gh api -X DELETE "repos/${REPO}/environments/production/deployment-branch-policies/${policy_id}" --silent 2>/dev/null || true
-        info "  Removed policy ID: $policy_id"
-      fi
-    done <<< "$EXISTING_POLICIES"
+PAYLOAD
+)" || APPLY_FAILURES=$((APPLY_FAILURES + 1))
   fi
 
-  # Add main branch policy
-  gh api -X POST "repos/${REPO}/environments/production/deployment-branch-policies" \
-    --input - <<EOF
-{
-  "name": "main",
-  "type": "branch"
-}
-EOF
-  success "Production deployment restricted to 'main' branch only"
-
-  # =========================================================================
-  # Step 3: Configure Development Environment
-  # =========================================================================
-
-  header "Step 3: Configuring Development Environment"
-
-  subhead "Creating/updating development environment with branch policy"
-  info "Setting deployment branch policy: develop only"
-  info "No required reviewers (fast iteration for dev)"
-
-  # Create/update the development environment
-  # No reviewers, no wait timer — just branch restriction
-  gh api -X PUT "repos/${REPO}/environments/development" \
-    --input - <<EOF
+  if [[ "$DRIFT_ENV_DEV" == true ]]; then
+    subhead "Remediating: Development Environment"
+    info "Desired: no reviewers, branch=develop"
+    apply_environment "development" "develop" "$(cat <<PAYLOAD
 {
   "deployment_branch_policy": {
     "protected_branches": false,
     "custom_branch_policies": true
   }
 }
-EOF
-  success "Development environment configured"
-
-  # Set deployment branch policy to develop only
-  subhead "Configuring deployment branch policies for development"
-
-  EXISTING_DEV_POLICIES=$(gh api "repos/${REPO}/environments/development/deployment-branch-policies" --jq '.branch_policies[].id' 2>/dev/null || echo "")
-  if [[ -n "$EXISTING_DEV_POLICIES" ]]; then
-    info "Removing existing deployment branch policies..."
-    while IFS= read -r policy_id; do
-      if [[ -n "$policy_id" ]]; then
-        gh api -X DELETE "repos/${REPO}/environments/development/deployment-branch-policies/${policy_id}" --silent 2>/dev/null || true
-        info "  Removed policy ID: $policy_id"
-      fi
-    done <<< "$EXISTING_DEV_POLICIES"
+PAYLOAD
+)" || APPLY_FAILURES=$((APPLY_FAILURES + 1))
   fi
 
-  # Add develop branch policy
-  gh api -X POST "repos/${REPO}/environments/development/deployment-branch-policies" \
-    --input - <<EOF
-{
-  "name": "develop",
-  "type": "branch"
-}
-EOF
-  success "Development deployment restricted to 'develop' branch only"
+  if [[ "$DRIFT_BRANCH_MAIN" == true ]]; then
+    subhead "Remediating: Main Branch Protection"
+    apply_branch_protection "main" || APPLY_FAILURES=$((APPLY_FAILURES + 1))
+  fi
+
+  if [[ "$DRIFT_BRANCH_DEVELOP" == true ]]; then
+    subhead "Remediating: Develop Branch Protection"
+    apply_branch_protection "develop" || APPLY_FAILURES=$((APPLY_FAILURES + 1))
+  fi
+
+  if [[ "$APPLY_FAILURES" -gt 0 ]]; then
+    fail "${APPLY_FAILURES} remediation(s) failed"
+  fi
 fi
 
 # =============================================================================
-# Step 4: Configure Main Branch Protection
+# Step 5: Post-Apply Verification
 # =============================================================================
 
-if [[ "$SKIP_BRANCH" != true ]]; then
-  header "Step 4: Configuring Main Branch Protection"
+if [[ "$DRIFT_COUNT" -gt 0 ]]; then
+  header "Step 5: Post-Apply Verification"
 
-  subhead "Setting branch protection for 'main'"
-  info "Require pull request: yes (1 approving review)"
-  info "Require code owner reviews: no (allows self-approve as admin)"
-  info "Dismiss stale reviews: no (flexibility for iterative PRs)"
-  info "Enforce admins: no (admin bypass for sole contributor)"
-  info "Require conversation resolution: yes"
-  info "Allow force pushes: no"
-  info "Allow deletions: no"
+  capture_environment_state "production" "${SNAPSHOT_DIR}/post_env_production.json"
+  capture_environment_state "development" "${SNAPSHOT_DIR}/post_env_development.json"
+  capture_branch_protection_state "main" "${SNAPSHOT_DIR}/post_branch_main.json"
+  capture_branch_protection_state "develop" "${SNAPSHOT_DIR}/post_branch_develop.json"
 
-  gh api -X PUT "repos/${REPO}/branches/main/protection" \
-    --input - <<EOF
-{
-  "required_status_checks": null,
-  "enforce_admins": false,
-  "required_pull_request_reviews": {
-    "dismiss_stale_reviews": false,
-    "require_code_owner_reviews": false,
-    "required_approving_review_count": 1
-  },
-  "restrictions": null,
-  "required_conversation_resolution": true,
-  "allow_force_pushes": false,
-  "allow_deletions": false
-}
-EOF
-  success "Main branch protection configured"
+  VERIFY_FAILURES=0
 
-  # =========================================================================
-  # Step 5: Configure Develop Branch Protection
-  # =========================================================================
+  if [[ "$SKIP_ENVIRONMENT" != true ]]; then
+    check_drift "Production Environment (verify)" "${SNAPSHOT_DIR}/post_env_production.json" "${SNAPSHOT_DIR}/desired_env_production.json" || {
+      VERIFY_FAILURES=$((VERIFY_FAILURES + 1))
+    }
+    check_drift "Development Environment (verify)" "${SNAPSHOT_DIR}/post_env_development.json" "${SNAPSHOT_DIR}/desired_env_development.json" || {
+      VERIFY_FAILURES=$((VERIFY_FAILURES + 1))
+    }
+  fi
 
-  header "Step 5: Configuring Develop Branch Protection"
+  if [[ "$SKIP_BRANCH" != true ]]; then
+    check_drift "Main Branch Protection (verify)" "${SNAPSHOT_DIR}/post_branch_main.json" "${SNAPSHOT_DIR}/desired_branch_main.json" || {
+      VERIFY_FAILURES=$((VERIFY_FAILURES + 1))
+    }
+    check_drift "Develop Branch Protection (verify)" "${SNAPSHOT_DIR}/post_branch_develop.json" "${SNAPSHOT_DIR}/desired_branch_develop.json" || {
+      VERIFY_FAILURES=$((VERIFY_FAILURES + 1))
+    }
+  fi
 
-  subhead "Setting branch protection for 'develop'"
-  info "Require pull request: yes (1 approving review)"
-  info "Require code owner reviews: no"
-  info "Dismiss stale reviews: no"
-  info "Enforce admins: no (admin bypass for sole contributor)"
-  info "Require conversation resolution: yes"
-  info "Allow force pushes: no"
-  info "Allow deletions: no"
-
-  gh api -X PUT "repos/${REPO}/branches/develop/protection" \
-    --input - <<EOF
-{
-  "required_status_checks": null,
-  "enforce_admins": false,
-  "required_pull_request_reviews": {
-    "dismiss_stale_reviews": false,
-    "require_code_owner_reviews": false,
-    "required_approving_review_count": 1
-  },
-  "restrictions": null,
-  "required_conversation_resolution": true,
-  "allow_force_pushes": false,
-  "allow_deletions": false
-}
-EOF
-  success "Develop branch protection configured"
-fi
-
-# =============================================================================
-# Step 6: Capture Post-Configuration State
-# =============================================================================
-
-header "Step 6: Capturing Post-Configuration State"
-
-capture_environment_state "production" "${SNAPSHOT_DIR}/post_env_production.json"
-capture_environment_state "development" "${SNAPSHOT_DIR}/post_env_development.json"
-capture_branch_protection_state "main" "${SNAPSHOT_DIR}/post_branch_main.json"
-capture_branch_protection_state "develop" "${SNAPSHOT_DIR}/post_branch_develop.json"
-
-display_state "Production Environment (after)" "${SNAPSHOT_DIR}/post_env_production.json"
-display_state "Development Environment (after)" "${SNAPSHOT_DIR}/post_env_development.json"
-display_state "Main Branch Protection (after)" "${SNAPSHOT_DIR}/post_branch_main.json"
-display_state "Develop Branch Protection (after)" "${SNAPSHOT_DIR}/post_branch_develop.json"
-
-# =============================================================================
-# Step 7: Compare Pre/Post State
-# =============================================================================
-
-header "Step 7: Configuration Changes Summary"
-
-CHANGES=0
-
-compare_state() {
-  local label="$1"
-  local pre_file="$2"
-  local post_file="$3"
-
-  if ! diff -q "$pre_file" "$post_file" &>/dev/null; then
-    subhead "CHANGED: $label"
-    diff --color=always \
-      <(jq --sort-keys '.' "$pre_file" 2>/dev/null) \
-      <(jq --sort-keys '.' "$post_file" 2>/dev/null) \
-      || true
-    CHANGES=$((CHANGES + 1))
+  if [[ "$VERIFY_FAILURES" -gt 0 ]]; then
+    warn "${VERIFY_FAILURES} resource(s) still show drift after remediation"
   else
-    info "No change: $label"
+    success "All resources verified — post-apply state matches desired state"
   fi
-}
 
-compare_state "Production Environment" "${SNAPSHOT_DIR}/pre_env_production.json" "${SNAPSHOT_DIR}/post_env_production.json"
-compare_state "Development Environment" "${SNAPSHOT_DIR}/pre_env_development.json" "${SNAPSHOT_DIR}/post_env_development.json"
-compare_state "Main Branch Protection" "${SNAPSHOT_DIR}/pre_branch_main.json" "${SNAPSHOT_DIR}/post_branch_main.json"
-compare_state "Develop Branch Protection" "${SNAPSHOT_DIR}/pre_branch_develop.json" "${SNAPSHOT_DIR}/post_branch_develop.json"
+  # Show what actually changed (pre vs post)
+  header "Changes Applied (before vs after)"
+
+  CHANGES=0
+
+  compare_pre_post() {
+    local label="$1"
+    local pre_file="$2"
+    local post_file="$3"
+
+    if ! diff -q <(jq --sort-keys '.' "$pre_file" 2>/dev/null) <(jq --sort-keys '.' "$post_file" 2>/dev/null) &>/dev/null; then
+      subhead "CHANGED: $label"
+      diff --color=always \
+        <(jq --sort-keys '.' "$pre_file" 2>/dev/null) \
+        <(jq --sort-keys '.' "$post_file" 2>/dev/null) \
+        | sed 's/^/  /' || true
+      CHANGES=$((CHANGES + 1))
+    else
+      info "No change: $label"
+    fi
+  }
+
+  if [[ "$SKIP_ENVIRONMENT" != true ]]; then
+    compare_pre_post "Production Environment" "${SNAPSHOT_DIR}/current_env_production.json" "${SNAPSHOT_DIR}/post_env_production.json"
+    compare_pre_post "Development Environment" "${SNAPSHOT_DIR}/current_env_development.json" "${SNAPSHOT_DIR}/post_env_development.json"
+  fi
+  if [[ "$SKIP_BRANCH" != true ]]; then
+    compare_pre_post "Main Branch Protection" "${SNAPSHOT_DIR}/current_branch_main.json" "${SNAPSHOT_DIR}/post_branch_main.json"
+    compare_pre_post "Develop Branch Protection" "${SNAPSHOT_DIR}/current_branch_develop.json" "${SNAPSHOT_DIR}/post_branch_develop.json"
+  fi
+fi
 
 # =============================================================================
 # Summary
 # =============================================================================
 
-header "Configuration Complete"
+header "Summary"
 echo ""
 
-if [[ "$CHANGES" -gt 0 ]]; then
-  success "$CHANGES configuration(s) changed"
+if [[ "$DRIFT_COUNT" -eq 0 ]]; then
+  success "All resources were already in compliance — no changes made"
 else
-  info "No changes detected (settings may have already been configured)"
+  success "${DRIFT_COUNT} resource(s) remediated"
 fi
 
 echo ""
-echo -e "${BOLD}Protection Rules Applied:${NC}"
+echo -e "${BOLD}Desired Protection Rules:${NC}"
 echo ""
 
 if [[ "$SKIP_ENVIRONMENT" != true ]]; then

--- a/scripts/create-backlog-issues.sh
+++ b/scripts/create-backlog-issues.sh
@@ -43,7 +43,7 @@ done
 
 # Fall back to current repo if not provided
 if [[ -z "$REPO" ]]; then
-  REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+  REPO="$(git remote get-url origin 2>/dev/null | sed -E 's#.*github\.com[:/]([^/]+/[^/.]+)(\.git)?$#\1#')"
 fi
 
 if [[ ! -d "$ISSUES_DIR" ]]; then

--- a/scripts/generate-phase-retrospective.sh
+++ b/scripts/generate-phase-retrospective.sh
@@ -38,7 +38,7 @@ if [[ -z "$PHASE" ]]; then
 fi
 
 if [[ -z "$REPO" ]]; then
-  REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+  REPO="$(git remote get-url origin 2>/dev/null | sed -E 's#.*github\.com[:/]([^/]+/[^/.]+)(\.git)?$#\1#')"
 fi
 
 OWNER="$(echo "$REPO" | cut -d/ -f1)"

--- a/scripts/setup-codespace-auth.sh
+++ b/scripts/setup-codespace-auth.sh
@@ -82,7 +82,7 @@ echo ""
 if [[ -n "$REPO_ARG" ]]; then
   REPO="$REPO_ARG"
 elif command -v gh &>/dev/null; then
-  REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || echo "unknown")
+  REPO=$(git remote get-url origin 2>/dev/null | sed -E 's#.*github\.com[:/]([^/]+/[^/.]+)(\.git)?$#\1#' || echo "unknown")
 else
   REPO="unknown"
 fi

--- a/scripts/setup-github-labels.sh
+++ b/scripts/setup-github-labels.sh
@@ -6,7 +6,7 @@
 
 set -euo pipefail
 
-REPO="${1:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
+REPO="${1:-$(git remote get-url origin 2>/dev/null | sed -E 's#.*github\.com[:/]([^/]+/[^/.]+)(\.git)?$#\1#')}"
 
 echo "Setting up labels for: $REPO"
 

--- a/scripts/setup-github-milestones.sh
+++ b/scripts/setup-github-milestones.sh
@@ -11,7 +11,7 @@
 
 set -euo pipefail
 
-REPO="${1:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
+REPO="${1:-$(git remote get-url origin 2>/dev/null | sed -E 's#.*github\.com[:/]([^/]+/[^/.]+)(\.git)?$#\1#')}"
 
 echo "Setting up milestones for: $REPO"
 echo ""

--- a/scripts/verify-credentials.sh
+++ b/scripts/verify-credentials.sh
@@ -38,24 +38,46 @@ done
 
 ENV="${1:---dev}"
 
-# Dev environment resource names
-DEV_BACKEND_RG="cus1-resume-be-dev-v1-rg"
-DEV_FRONTEND_RG="cus1-resume-fe-dev-v1-rg"
-DEV_KEYVAULT="cus1-resume-dev-v1-kv"
-DEV_FUNCTIONAPP="cus1-resumectr-dev-v1-fa"
-DEV_COSMOSDB="cus1-resume-dev-v1-cmsdb"
-DEV_DNS_RECORD="resumedevv1.ryanmcvey.me"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEV_WORKFLOW="${SCRIPT_DIR}/../.github/workflows/dev-full-stack-cloudflare.yml"
+PROD_WORKFLOW="${SCRIPT_DIR}/../.github/workflows/prod-full-stack-cloudflare.yml"
 
-# Production environment resource names
-PROD_BACKEND_RG="cus1-resume-be-prod-v1-rg"
-PROD_FRONTEND_RG="cus1-resume-fe-prod-v1-rg"
-PROD_KEYVAULT="cus1-resume-prod-v1-kv"
-PROD_FUNCTIONAPP="cus1-resumectr-prod-v1-fa"
-PROD_COSMOSDB="cus1-resume-prod-v1-cmsdb"
-PROD_DNS_RECORD="resume.ryanmcvey.me"
+# Parse a top-level env var from a workflow YAML file.
+# Usage: parse_workflow_var <file> <varName>
+parse_workflow_var() {
+  local file="$1" var="$2"
+  grep -E "^\s+${var}:" "$file" | head -1 | sed -E "s/^\s+${var}:\s*['\"]?([^'\"]+)['\"]?.*$/\1/"
+}
 
-DNS_ZONE="ryanmcvey.me"
+# Load stack config from a workflow file and set resource name variables.
+# Sets: BACKEND_RG, FRONTEND_RG, KEYVAULT, FUNCTIONAPP, COSMOSDB, DNS_RECORD, DNS_ZONE
+load_stack_config() {
+  local wf_file="$1"
+  if [[ ! -f "$wf_file" ]]; then
+    echo "Error: Workflow file not found: $wf_file" >&2
+    exit 1
+  fi
+  local ver loc app app_be prefix zone
+  ver=$(parse_workflow_var "$wf_file" stackVersion)
+  loc=$(parse_workflow_var "$wf_file" stackLocationCode)
+  app=$(parse_workflow_var "$wf_file" AppName)
+  app_be=$(parse_workflow_var "$wf_file" AppBackendName)
+  env_tier=$(parse_workflow_var "$wf_file" stackEnvironment)
+  prefix=$(parse_workflow_var "$wf_file" customDomainPrefix)
+  zone=$(parse_workflow_var "$wf_file" dnsZone)
+
+  BACKEND_RG="${loc}-${app}-be-${env_tier}-${ver}-rg"
+  FRONTEND_RG="${loc}-${app}-fe-${env_tier}-${ver}-rg"
+  KEYVAULT="${loc}-${app}-${env_tier}-${ver}-kv"
+  FUNCTIONAPP="${loc}-${app_be}-${env_tier}-${ver}-fa"
+  COSMOSDB="${loc}-${app}-${env_tier}-${ver}-cmsdb"
+  DNS_RECORD="${prefix}.${zone}"
+  DNS_ZONE="${zone}"
+}
+
 SP_DISPLAY_NAME="azureresumeiac-github-sp"
+# DNS zone is the same for all environments — load it early for Cloudflare checks
+DNS_ZONE=$(parse_workflow_var "$DEV_WORKFLOW" dnsZone)
 
 PASS=0
 WARN=0
@@ -215,11 +237,11 @@ else
     pass "GitHub CLI authenticated as: $GH_USER"
 
     # Check repo access
-    REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || echo "unknown")
-    if [[ "$REPO" != "unknown" ]]; then
-      pass "Repository access: $REPO"
+    REPO=$(git remote get-url origin 2>/dev/null | sed -E 's#.*github\.com[:/]([^/]+/[^/.]+)(\.git)?$#\1#' || echo "unknown")
+    if [[ "$REPO" != "unknown" && -n "$REPO" ]]; then
+      pass "Repository detected from git origin: $REPO"
     else
-      warn "Could not detect repository context"
+      warn "Could not detect repository from git origin remote"
     fi
   else
     fail "GitHub CLI not authenticated — run: gh auth login"
@@ -298,14 +320,18 @@ check_env_resources() {
 
 case "$ENV" in
   --dev)
-    check_env_resources "Development" "$DEV_BACKEND_RG" "$DEV_FRONTEND_RG" "$DEV_KEYVAULT" "$DEV_FUNCTIONAPP" "$DEV_COSMOSDB" "$DEV_DNS_RECORD"
+    load_stack_config "$DEV_WORKFLOW"
+    check_env_resources "Development" "$BACKEND_RG" "$FRONTEND_RG" "$KEYVAULT" "$FUNCTIONAPP" "$COSMOSDB" "$DNS_RECORD"
     ;;
   --prod)
-    check_env_resources "Production" "$PROD_BACKEND_RG" "$PROD_FRONTEND_RG" "$PROD_KEYVAULT" "$PROD_FUNCTIONAPP" "$PROD_COSMOSDB" "$PROD_DNS_RECORD"
+    load_stack_config "$PROD_WORKFLOW"
+    check_env_resources "Production" "$BACKEND_RG" "$FRONTEND_RG" "$KEYVAULT" "$FUNCTIONAPP" "$COSMOSDB" "$DNS_RECORD"
     ;;
   --all)
-    check_env_resources "Development" "$DEV_BACKEND_RG" "$DEV_FRONTEND_RG" "$DEV_KEYVAULT" "$DEV_FUNCTIONAPP" "$DEV_COSMOSDB" "$DEV_DNS_RECORD"
-    check_env_resources "Production" "$PROD_BACKEND_RG" "$PROD_FRONTEND_RG" "$PROD_KEYVAULT" "$PROD_FUNCTIONAPP" "$PROD_COSMOSDB" "$PROD_DNS_RECORD"
+    load_stack_config "$DEV_WORKFLOW"
+    check_env_resources "Development" "$BACKEND_RG" "$FRONTEND_RG" "$KEYVAULT" "$FUNCTIONAPP" "$COSMOSDB" "$DNS_RECORD"
+    load_stack_config "$PROD_WORKFLOW"
+    check_env_resources "Production" "$BACKEND_RG" "$FRONTEND_RG" "$KEYVAULT" "$FUNCTIONAPP" "$COSMOSDB" "$DNS_RECORD"
     ;;
   *)
     echo "Usage: $0 [--dev | --prod | --all]"

--- a/scripts/verify-keyvault-access.sh
+++ b/scripts/verify-keyvault-access.sh
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash
 # Key Vault Access Verification Script
 # Verifies all acceptance criteria for Phase 1 - Verify Key Vault access
+#
+# Resource names are sourced dynamically from the workflow YAML files
+# (.github/workflows/dev-full-stack-cloudflare.yml or prod-full-stack-cloudflare.yml).
+#
+# Usage:
+#   bash scripts/verify-keyvault-access.sh [--dev | --prod]
+#
+# Options:
+#   --dev   Verify dev environment (default)
+#   --prod  Verify production environment
 set -euo pipefail
 
 # Prerequisite checks
@@ -16,10 +26,44 @@ require_cmd az
 require_cmd jq
 require_cmd curl
 
-# Configuration (edit for your environment)
-KEY_VAULT_NAME="${1:-cus1-resume-prod-v1-kv}"
-RESOURCE_GROUP="${2:-cus1-resume-be-prod-v1-rg}"
-FUNCTION_APP_NAME="${3:-cus1-resumectr-prod-v1-fa}"
+# =============================================================================
+# Dynamic stack configuration from workflow YAML
+# =============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEV_WORKFLOW="${SCRIPT_DIR}/../.github/workflows/dev-full-stack-cloudflare.yml"
+PROD_WORKFLOW="${SCRIPT_DIR}/../.github/workflows/prod-full-stack-cloudflare.yml"
+
+# Parse a top-level env var from a workflow YAML file.
+parse_workflow_var() {
+  local file="$1" var="$2"
+  grep -E "^\s+${var}:" "$file" | head -1 | sed -E "s/^\s+${var}:\s*['\"]?([^'\"]+)['\"]?.*$/\1/"
+}
+
+ENV_FLAG="${1:---dev}"
+case "$ENV_FLAG" in
+  --dev)  WF_FILE="$DEV_WORKFLOW" ;;
+  --prod) WF_FILE="$PROD_WORKFLOW" ;;
+  *)
+    echo "Usage: $0 [--dev | --prod]"
+    exit 1
+    ;;
+esac
+
+if [[ ! -f "$WF_FILE" ]]; then
+  echo "Error: Workflow file not found: $WF_FILE" >&2
+  exit 1
+fi
+
+_ver=$(parse_workflow_var "$WF_FILE" stackVersion)
+_loc=$(parse_workflow_var "$WF_FILE" stackLocationCode)
+_app=$(parse_workflow_var "$WF_FILE" AppName)
+_app_be=$(parse_workflow_var "$WF_FILE" AppBackendName)
+_env=$(parse_workflow_var "$WF_FILE" stackEnvironment)
+
+KEY_VAULT_NAME="${_loc}-${_app}-${_env}-${_ver}-kv"
+RESOURCE_GROUP="${_loc}-${_app}-be-${_env}-${_ver}-rg"
+FUNCTION_APP_NAME="${_loc}-${_app_be}-${_env}-${_ver}-fa"
 SECRET_NAME_PRIMARY="AzureResumeConnectionStringPrimary"
 SECRET_NAME_SECONDARY="AzureResumeConnectionStringSecondary"
 


### PR DESCRIPTION
## Summary

Fix repo auto-detection bug in 8 scripts and add idempotent desired-state configuration for environment/branch protection rules, plus dynamic stack naming for verification scripts.

## Changes

### Repo detection fix (all 8 scripts)
- **Root cause:** `gh repo view --json nameWithOwner` follows fork parents and resolved to `dewolfs/bicep-github-actions` instead of our fork `rmcveyhsawaknow/azure-resume-iac`
- **Fix:** Replaced with `git remote get-url origin | sed` parsing — handles both HTTPS and SSH URLs

### `configure-repo-protection.sh` — full rewrite
- Desired-state model: define expected JSON for 4 resources (production env, development env, main branch, develop branch)
- Capture current state via GitHub API, diff against desired state
- `--dry-run` audit mode: exit 0 = compliant, exit 2 = drift detected
- Only apply changes where drift is found (delta-based remediation)
- Post-apply verification confirms desired state was achieved
- Permissions-aware: gracefully skips resources when token lacks `administration` scope (Codespace limitation)
- New options: `--wait-timer`, `--skip-branch`, `--skip-environment`, `--reviewer`, `--repo`

### `verify-credentials.sh` — dynamic stack config
- Replaced 12 hardcoded resource name variables with `parse_workflow_var()` + `load_stack_config()` that reads from workflow YAML files
- Resource names sourced from `.github/workflows/dev-full-stack-cloudflare.yml` or `prod-full-stack-cloudflare.yml`
- `--dev`, `--prod`, `--all` flags select which workflow to parse

### `verify-keyvault-access.sh` — dynamic stack config + env switch
- Replaced positional parameters (`$1`, `$2`, `$3`) with `--dev`/`--prod` flag
- Resource names computed dynamically from workflow YAML (same pattern as verify-credentials.sh)
- Default changed from prod-only to `--dev` (matching verify-credentials.sh)

## Testing
- All 8 scripts pass `bash -n` syntax checks
- `configure-repo-protection.sh --dry-run` correctly detects repo and reports drift
- `verify-credentials.sh --dev` resolves to v10 stack (from workflow), not stale v1
- `verify-credentials.sh --prod` resolves to v1 stack (from workflow)
- `verify-keyvault-access.sh --dev` and `--prod` both resolve correctly