### PR TITLE
[Phase 3] Update storage account min TLS to 1.2, bump dev to v11

### DIFF
--- a/.github/workflows/dev-full-stack-cloudflare.yml
+++ b/.github/workflows/dev-full-stack-cloudflare.yml
@@ -21,7 +21,7 @@ env:
   # instead of updating the existing one. When you do this, make sure to:
   # - Decommission and delete the old dev resource groups to avoid orphaned costs.
   # - Clean up any obsolete Cloudflare DNS records that pointed to the old stack.
-  stackVersion: 'v10'
+  stackVersion: 'v11'
   stackEnvironment: 'dev'
   stackLocation: 'eastus'
   stackLocationCode: 'cus1'

--- a/.iac/modules/functionapp/functionapp.bicep
+++ b/.iac/modules/functionapp/functionapp.bicep
@@ -96,6 +96,7 @@ resource functionAppStorageAccount 'Microsoft.Storage/storageAccounts@2021-04-01
   kind: 'StorageV2'
   properties: {
     supportsHttpsTrafficOnly: true
+    minimumTlsVersion: 'TLS1_2'
     encryption: {
       services: {
         file: {

--- a/.iac/modules/storageaccount/sa_staticsite.bicep
+++ b/.iac/modules/storageaccount/sa_staticsite.bicep
@@ -32,6 +32,7 @@ resource frontendStaticSite 'Microsoft.Storage/storageAccounts@2021-04-01' = {
   kind: 'StorageV2'
   properties: {
     supportsHttpsTrafficOnly: true
+    minimumTlsVersion: 'TLS1_2'
   }
   tags: {
     Environment: tagEnvironmentNameTier


### PR DESCRIPTION
## Summary

Resolves #135 — Enforce TLS 1.2 on all storage accounts (Phase 0 gap analysis finding F11, Issue #16).

## Changes

### Bicep — Storage Account TLS Hardening
- **`.iac/modules/storageaccount/sa_staticsite.bicep`** — Added `minimumTlsVersion: 'TLS1_2'` to the frontend static site storage account `properties` block
- **`.iac/modules/functionapp/functionapp.bicep`** — Added `minimumTlsVersion: 'TLS1_2'` to the function app storage account `properties` block

### Workflow — Dev Stack Version Bump
- **`.github/workflows/dev-full-stack-cloudflare.yml`** — Bumped `stackVersion` from `v10` → `v11` to deploy a new blue/green dev stack with the TLS fix baked in

## Breaking Change Analysis

**No breaking changes.** TLS 1.2 is universally supported by all components in the architecture:
- Cloudflare origin pulls use TLS 1.2+ by default
- All modern browsers support TLS 1.2 since ~2013
- .NET 8 / Azure Functions v4 runtime uses TLS 1.2+ natively
- Azure CLI and Cosmos DB SDK default to TLS 1.2+

## Post-Merge Steps

1. Merge triggers dev workflow → deploys new v11 stack with TLS 1.2
2. Verify via `az storage account show --query minimumTlsVersion` on both new v11 storage accounts
3. Validate `https://resumedev.ryanmcvey.me` loads and counter API works
4. Inventory old v10 stack: `scripts/cleanup-stack.sh --inventory --json-output artifacts/inventory-dev-v10.json`
5. Purge old v10 stack: `scripts/cleanup-stack.sh --purge`

## Acceptance Criteria from Issue #135

- [x] Bicep template updated: `minimumTlsVersion: 'TLS1_2'` for all storage accounts
- [ ] Verified via `az storage account show` after deployment _(post-merge)_
- [ ] No impact on static website serving _(post-merge validation)_