### PR TITLE
fix(dns): Add upsert support to cloudflare-dns-record.sh for blue/green swaps

### DIFF
--- a/scripts/cloudflare-dns-record.sh
+++ b/scripts/cloudflare-dns-record.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# cloudflare-dns-record.sh — Check-before-create a Cloudflare DNS record.
+# cloudflare-dns-record.sh — Upsert a Cloudflare DNS record (create or update).
 #
 # Required environment variables:
 #   CF_TOKEN         Cloudflare API Bearer token
@@ -10,8 +10,8 @@
 #   RECORD_PROXIED   "true" or "false" — whether to proxy through Cloudflare
 #
 # Exit codes:
-#   0  Record already exists with correct content, or was created successfully
-#   1  API error, HTTP error, or record exists with different content
+#   0  Record already exists with correct content, was created, or was updated
+#   1  API error or HTTP error
 set -euo pipefail
 
 TMPDIR_CF=$(mktemp -d)
@@ -40,7 +40,7 @@ if [ "$GET_SUCCESS" != "true" ]; then
 fi
 
 ##############################################################################
-# Step 2 — Decide: skip / warn / create
+# Step 2 — Decide: skip / update / create
 ##############################################################################
 COUNT=$(jq '.result | length' "${TMPDIR_CF}/get.json")
 
@@ -51,8 +51,36 @@ if [ "$COUNT" -gt 0 ]; then
     echo "✅ DNS record ${RECORD_NAME} already exists with correct content and proxy setting"
     exit 0
   else
-    echo "::warning::DNS record ${RECORD_NAME} exists but differs (content: ${CURRENT} vs ${RECORD_CONTENT}, proxied: ${CURRENT_PROXIED} vs ${RECORD_PROXIED})"
-    exit 1
+    # Record exists with different content — update it (blue/green re-point)
+    RECORD_ID=$(jq -r '.result[0].id' "${TMPDIR_CF}/get.json")
+    echo "Updating DNS record ${RECORD_NAME} (${RECORD_ID}): ${CURRENT} → ${RECORD_CONTENT}"
+
+    PUT_PAYLOAD=$(jq -n \
+      --arg type "$RECORD_TYPE" \
+      --arg name "$RECORD_NAME" \
+      --arg content "$RECORD_CONTENT" \
+      --argjson proxied "$RECORD_PROXIED" \
+      '{type: $type, name: $name, content: $content, ttl: 1, proxied: $proxied}')
+
+    PUT_HTTP=$(curl -sS -o "${TMPDIR_CF}/put.json" -w '%{http_code}' -X PUT \
+      "${API_BASE}/${RECORD_ID}" \
+      -H "${AUTH_HEADER}" -H "${CT_HEADER}" \
+      --data "$PUT_PAYLOAD")
+
+    if [ "$PUT_HTTP" -lt 200 ] || [ "$PUT_HTTP" -ge 300 ]; then
+      echo "::error::Cloudflare DNS PUT HTTP error ${PUT_HTTP}: $(cat "${TMPDIR_CF}/put.json")"
+      exit 1
+    fi
+
+    PUT_SUCCESS=$(jq -r '.success' "${TMPDIR_CF}/put.json")
+    if [ "$PUT_SUCCESS" != "true" ]; then
+      echo "::error::Cloudflare DNS PUT API failure: $(cat "${TMPDIR_CF}/put.json")"
+      exit 1
+    fi
+
+    echo "✅ DNS record ${RECORD_NAME} updated successfully"
+    jq . "${TMPDIR_CF}/put.json"
+    exit 0
   fi
 fi
 


### PR DESCRIPTION
## Problem

Workflow run #65 failed at the "Enable Storage Account Frontend Cloudflare Custom Domain" step after merging PR #213 (TLS 1.2 + stack version bump v10→v11).

**Root cause:** `scripts/cloudflare-dns-record.sh` only supported **check-before-create**. When the CNAME and asverify DNS records already existed (pointing to v10 storage), the script detected the content mismatch and exited 1 instead of updating.

This caused a chain failure:
1. **Cloudflare - Frontend DNS Verify** (asverify CNAME) — exited 1, `continue-on-error` let the workflow proceed
2. **Wait for DNS Propagation** — DNS resolved (to old v10 target), passed
3. **Enable Storage Account Frontend Cloudflare Custom Domain** — Azure tried to verify ownership via the asverify CNAME, but it still pointed to v10 → `StorageDomainNameCouldNotVerify` error after all 5 retries

**This is a blue/green deployment gap** — the script was never designed for stack version swaps where DNS records must be re-pointed.

## Fix

When a record exists with **different content**, the script now **updates it via PUT** instead of warning and exiting 1:

```
# Before (line 55-56):
echo "::warning::DNS record exists but differs..."
exit 1

# After:
RECORD_ID=$(jq -r '.result[0].id')
curl -X PUT "${API_BASE}/${RECORD_ID}" ... # update with new content
```

The three code paths are now:
| Scenario | Action | Exit |
|---|---|---|
| Record exists, content matches | Skip | 0 |
| Record exists, content differs | **PUT update** | 0 |
| Record does not exist | POST create | 0 |

## Testing

This fix will be validated when the workflow is re-run after merge — the DNS steps will update the CNAME/asverify records to point to v11, and the custom domain step will succeed.

## Files Changed

- `scripts/cloudflare-dns-record.sh` — Added PUT/update logic in Step 2; updated header comment and exit code docs

Related: #135